### PR TITLE
option to apply cancel-item-move only to player's inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+#intellij
+.idea/
+*.iml
+
 # eclipse
 .project
 .settings

--- a/resources/config/inventory.yml
+++ b/resources/config/inventory.yml
@@ -10,6 +10,9 @@ cancel-item-drop: false
 # this includes swapping items between hands for 1.9+)
 cancel-item-move: false
 
+# Should cancel item move only cancel it if its from a players inventory?
+cancel-item-move-player-only: false
+
 
 # -------------------- Advanced -------------------- #
 

--- a/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
+++ b/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
@@ -33,9 +33,7 @@ public class ItemMoveDropCancelListener implements Listener {
 			Bukkit.getPluginManager().registerEvents(new Listener() {
 				@EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
 				public void onItemMove(final InventoryClickEvent event){
-					if (inventory.getBoolean("cancel-item-move-player-only")) {
-						if (!event.getClickedInventory().getType().equals(InventoryType.PLAYER)) return;
-					}
+					if (inventory.getBoolean("cancel-item-move-player-only") && !event.getClickedInventory().getType().equals(InventoryType.PLAYER)) return;
 					if (!event.getWhoClicked().hasPermission("ssx.move")) {
 						event.setCancelled(true);
 					}

--- a/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
+++ b/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryDragEvent;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerSwapHandItemsEvent;
 
@@ -32,6 +33,9 @@ public class ItemMoveDropCancelListener implements Listener {
 			Bukkit.getPluginManager().registerEvents(new Listener() {
 				@EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
 				public void onItemMove(final InventoryClickEvent event){
+					if (inventory.getBoolean("cancel-item-move-player-only")) {
+						if (!event.getClickedInventory().getType().equals(InventoryType.PLAYER)) return;
+					}
 					if (!event.getWhoClicked().hasPermission("ssx.move")) {
 						event.setCancelled(true);
 					}

--- a/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
+++ b/src/xyz/derkades/serverselectorx/ItemMoveDropCancelListener.java
@@ -33,6 +33,7 @@ public class ItemMoveDropCancelListener implements Listener {
 			Bukkit.getPluginManager().registerEvents(new Listener() {
 				@EventHandler(ignoreCancelled = true, priority = EventPriority.LOW)
 				public void onItemMove(final InventoryClickEvent event){
+					if (event.getClickedInventory() == null) return;
 					if (inventory.getBoolean("cancel-item-move-player-only") && !event.getClickedInventory().getType().equals(InventoryType.PLAYER)) return;
 					if (!event.getWhoClicked().hasPermission("ssx.move")) {
 						event.setCancelled(true);


### PR DESCRIPTION
Should add the features from #168.

Haven't yet tested it cause I did something with Derkutils wrong, so I am getting some class not found errors & can't actually test it since the plugin won't load, but its like 5 new lines of code so I'd assume it will work.

Just drafting this for now, until I figure out what I did wrong and can test it.